### PR TITLE
칼럼 추가 기능 

### DIFF
--- a/docs/eslint-prettier.md
+++ b/docs/eslint-prettier.md
@@ -117,7 +117,7 @@ module.exports = {
   extends: [
     'airbnb-base',
     'plugin:vue/recommended',
-    'pretteir:prettier/recommended'
+    'plugin:prettier/recommended'
   ],
   plugins: ['vue', 'import'],
   env: {

--- a/src/components/AppComponent.vue
+++ b/src/components/AppComponent.vue
@@ -15,8 +15,3 @@ export default {
   }
 };
 </script>
-<style lang="scss">
-#id {
-  flex: display;
-}
-</style>

--- a/src/components/AppComponent.vue
+++ b/src/components/AppComponent.vue
@@ -1,9 +1,22 @@
-// AppComponent.vue
 <template>
-    <h1>Hello from the</h1>
+  <div id="app">
+    <main-header></main-header>
+    <board></board>
+  </div>
 </template>
 <script>
-  export default {
+import Board from './Board.vue';
+import MainHeader from './MainHeader.vue';
 
+export default {
+  components: {
+    MainHeader,
+    Board
   }
+};
 </script>
+<style lang="scss">
+#id {
+  flex: display;
+}
+</style>

--- a/src/components/Board.vue
+++ b/src/components/Board.vue
@@ -1,0 +1,43 @@
+<template>
+  <div id="board">
+    <column
+      v-for="column in columnList"
+      :key="column.id"
+      :title="column.title"
+    ></column>
+    <column-form @add-new-column="onAddNewColumn"></column-form>
+  </div>
+</template>
+<script>
+import Column from './Column.vue';
+import ColumnForm from './ColumnForm.vue';
+
+export default {
+  components: {
+    Column,
+    ColumnForm
+  },
+  data() {
+    return {
+      columnList: [{ id: 1, title: 'todo' }]
+    };
+  },
+  methods: {
+    onAddNewColumn(title) {
+      this.columnList.push({ id: `new-column-${title}`, title });
+    }
+  }
+};
+</script>
+<style lang="scss">
+#board {
+  display: flex;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 95vh;
+
+  overflow-x: scroll;
+  border: 1px solid red;
+}
+</style>

--- a/src/components/Column.vue
+++ b/src/components/Column.vue
@@ -1,0 +1,37 @@
+<template>
+  <div class="column">
+    <div class="column__title">
+      {{ title }}
+    </div>
+  </div>
+</template>
+<script>
+export default {
+  props: {
+    title: {
+      type: String,
+      required: true
+    }
+  }
+};
+</script>
+<style lang="scss">
+@import 'src/style/mixin.scss';
+@import 'src/style/variable.scss';
+
+.column {
+  @include round-box;
+  @include column-base;
+  background: $column-back;
+}
+.column__title {
+  @include round-box;
+  @include flex-center;
+  @include column-title-base;
+  font: {
+    size: 1.2em;
+    weight: 500;
+  }
+  background: $column-back;
+}
+</style>

--- a/src/components/ColumnForm.vue
+++ b/src/components/ColumnForm.vue
@@ -1,0 +1,52 @@
+<template>
+  <div id="column-form">
+    <h1 v-if="showForm">타이틀입력하기</h1>
+    <button v-else id="column-form__button" @click="toggleShowForm">
+      + Add another list
+    </button>
+  </div>
+</template>
+<script>
+export default {
+  data() {
+    return {
+      showForm: false
+    };
+  },
+  methods: {
+    toggleShowForm() {
+      this.showForm = this.showForm !== true;
+    }
+  }
+};
+</script>
+<style lang="scss">
+@use "sass:color";
+@import 'src/style/mixin.scss';
+@import 'src/style/variable.scss';
+
+#column-form {
+  @include round-box;
+  @include column-base;
+
+  background: #f9f9f9;
+}
+#column-form__button {
+  @include round-box;
+  @include column-title-base;
+
+  width: 100%;
+  border: lightgray;
+  background: color.scale($column-back, $lightness: 50%);
+  font: {
+    size: 1.2em;
+    weight: 500;
+  }
+
+  cursor: pointer;
+
+  &:hover {
+    background: color.scale($column-back, $lightness: 80%);
+  }
+}
+</style>

--- a/src/components/ColumnForm.vue
+++ b/src/components/ColumnForm.vue
@@ -1,21 +1,61 @@
 <template>
   <div id="column-form">
-    <h1 v-if="showForm">타이틀입력하기</h1>
+    <form v-if="showForm">
+      <input
+        id="column-form__input"
+        v-model.trim="title"
+        placeholder="Enter column title..."
+        :minlength="minTitle"
+        :maxlength="maxTitle"
+      />
+      <button
+        class="column-form__submit"
+        :class="{ active: isValidTitle }"
+        type="button"
+        @click="submitNewTitle"
+      >
+        Add List
+      </button>
+      <button id="column-form__cancel" type="button" @click="toggleShowForm">
+        X
+      </button>
+    </form>
     <button v-else id="column-form__button" @click="toggleShowForm">
       + Add another list
     </button>
   </div>
 </template>
 <script>
+import { MAX_TITLE_LENGTH, MIN_TITLE_LENGTH } from '../constants/title';
+
 export default {
   data() {
     return {
-      showForm: false
+      showForm: false,
+      title: '',
+      maxTitle: MAX_TITLE_LENGTH,
+      minTitle: MIN_TITLE_LENGTH
     };
+  },
+  computed: {
+    isValidTitle() {
+      return (
+        this.title.length >= MIN_TITLE_LENGTH &&
+        this.title.length <= MAX_TITLE_LENGTH
+      );
+    }
   },
   methods: {
     toggleShowForm() {
       this.showForm = this.showForm !== true;
+    },
+    submitNewTitle() {
+      this.$emit('add-new-column', this.title);
+      this.resetData();
+    },
+    resetData() {
+      this.showForm = false;
+      this.title = '';
     }
   }
 };
@@ -24,19 +64,31 @@ export default {
 @use "sass:color";
 @import 'src/style/mixin.scss';
 @import 'src/style/variable.scss';
+$padding: 0.5rem 0;
+
+.column-form__submit {
+  color: gray;
+}
+
+.active {
+  background: green;
+  color: white;
+  &:hover {
+    background: color.scale(green, $lightness: 10%);
+  }
+}
 
 #column-form {
   @include round-box;
   @include column-base;
-
-  background: #f9f9f9;
 }
+
 #column-form__button {
   @include round-box;
-  @include column-title-base;
 
   width: 100%;
   border: lightgray;
+  padding: $padding;
   background: color.scale($column-back, $lightness: 50%);
   font: {
     size: 1.2em;
@@ -44,9 +96,11 @@ export default {
   }
 
   cursor: pointer;
-
-  &:hover {
-    background: color.scale($column-back, $lightness: 80%);
-  }
+}
+#column-form__input {
+  @include column-title-base;
+  @include column-base;
+  width: 100%;
+  padding: $padding;
 }
 </style>

--- a/src/components/MainHeader.vue
+++ b/src/components/MainHeader.vue
@@ -1,0 +1,28 @@
+<template>
+  <header id="header">
+    {{ title }}
+  </header>
+</template>
+<script>
+export default {
+  data() {
+    return {
+      title: "Lillie's Trello"
+    };
+  }
+};
+</script>
+<style lang="scss">
+@import 'src/style/mixin.scss';
+
+#header {
+  @include flex-center;
+  color: #170f14;
+  font: {
+    size: 1.3em;
+    weight: 800;
+  }
+  background: #cdb1c1;
+  height: 3rem;
+}
+</style>

--- a/src/constants/title.js
+++ b/src/constants/title.js
@@ -1,0 +1,2 @@
+export const MAX_TITLE_LENGTH = 30;
+export const MIN_TITLE_LENGTH = 1;

--- a/src/index.html
+++ b/src/index.html
@@ -4,9 +4,10 @@
   <meta charset="UTF-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Document</title>
+  <title>Lillie's Trello</title>
 </head>
-<body id='app'>
-  
+<body id='body'>
+    <app-component>
+    </app-component>
 </body>
 </html>

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,11 @@
 // src/index.js
 import Vue from 'vue';
 import AppComponent from './components/AppComponent.vue';
-
+import './style/reset.scss';
+// root element
 new Vue({
-  render: h => h(AppComponent)
-}).$mount('#app');
+  el: '#body',
+  render(h) {
+    return h(AppComponent);
+  }
+});

--- a/src/style/mixin.scss
+++ b/src/style/mixin.scss
@@ -1,0 +1,19 @@
+@mixin round-box{
+  @content;
+  border-radius: 2rem;
+}
+
+@mixin flex-center{
+  display:flex;
+  justify-content: center;
+  align-items:center;
+  @content;
+}
+
+@mixin column-base{
+  min-width: 20em;
+}
+
+@mixin column-title-base{
+  max-height: 4em;
+}

--- a/src/style/mixin.scss
+++ b/src/style/mixin.scss
@@ -1,6 +1,6 @@
 @mixin round-box{
   @content;
-  border-radius: 2rem;
+  border-radius: 4%;
 }
 
 @mixin flex-center{
@@ -11,9 +11,12 @@
 }
 
 @mixin column-base{
-  min-width: 20em;
+  min-width:20em;
+  max-width: 20em;
 }
 
 @mixin column-title-base{
-  max-height: 4em;
+  height: 1.5rem;
+  padding: 1em 0;
+  border-bottom: 1px solid darkgray;
 }

--- a/src/style/reset.scss
+++ b/src/style/reset.scss
@@ -10,6 +10,7 @@ html, body, div, span, applet, object, iframe, h1, h2, h3, h4, h5, h6, p, blockq
   font-size: 100%;
   font: inherit;
   vertical-align: baseline; 
+  box-sizing: border-box;
 }
 
 /* HTML5 display-role reset for older browsers */

--- a/src/style/reset.scss
+++ b/src/style/reset.scss
@@ -1,0 +1,48 @@
+/* http://meyerweb.com/eric/tools/css/reset/ 
+   v2.0 | 20110126
+   License: none (public domain)
+*/
+
+html, body, div, span, applet, object, iframe, h1, h2, h3, h4, h5, h6, p, blockquote, pre, a, abbr, acronym, address, big, cite, code, del, dfn, em, img, ins, kbd, q, s, samp, small, strike, strong, sub, sup, tt, var, b, u, i, center, dl, dt, dd, ol, ul, li, fieldset, form, label, legend, table, caption, tbody, tfoot, thead, tr, th, td, article, aside, canvas, details, embed, figure, figcaption, footer, header, hgroup, menu, nav, output, ruby, section, summary, time, mark, audio, video {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-size: 100%;
+  font: inherit;
+  vertical-align: baseline; 
+}
+
+/* HTML5 display-role reset for older browsers */
+
+article, aside, details, figcaption, figure, footer, header, hgroup, menu, nav, section {
+  display: block; 
+}
+
+body {
+  line-height: 1; 
+}
+
+ol, ul {
+  list-style: none; 
+}
+
+blockquote, q {
+  quotes: none; 
+}
+
+blockquote {
+  &:before, &:after {
+    content: '';
+    content: none; } 
+}
+
+q {
+  &:before, &:after {
+    content: '';
+    content: none; } 
+}
+
+table {
+  border-collapse: collapse;
+  border-spacing: 0;
+}

--- a/src/style/variable.scss
+++ b/src/style/variable.scss
@@ -1,0 +1,1 @@
+$column-back: #dedce0;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,45 +1,49 @@
-const path = require("path");
-const HtmlWebpackPlugin = require("html-webpack-plugin");
-const MiniCssExtractPlugin = require("mini-css-extract-plugin");
-const CssMinimizerPlugin = require("css-minimizer-webpack-plugin");
-const { VueLoaderPlugin } = require("vue-loader");
+const path = require('path');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+const CssMinimizerPlugin = require('css-minimizer-webpack-plugin');
+const { VueLoaderPlugin } = require('vue-loader');
 
 module.exports = {
-  entry: "./src/index.js",
+  entry: './src/index.js',
   output: {
-    filename: "main.js",
-    path: path.resolve(__dirname, "dist"),
+    filename: 'main.js',
+    path: path.resolve(__dirname, 'dist')
   },
+  devtool: 'eval-source-map',
   plugins: [
     new VueLoaderPlugin(),
     new HtmlWebpackPlugin({
-      template: "src/index.html",
-      hash: true,
+      template: 'src/index.html',
+      hash: true
     }),
-    ...(process.env.NODE_ENV === "production"
+    ...(process.env.NODE_ENV === 'production'
       ? [new MiniCssExtractPlugin({ filename: `[name].css` })]
-      : []),
+      : [])
   ],
   module: {
     rules: [
       {
         test: /\.vue$/,
-        loader: "vue-loader",
+        loader: 'vue-loader',
+        options: {
+          extractCSS: true
+        }
       },
       {
         test: /\.s[ac]ss$/i,
         use: [
-          process.env.NODE_ENV === "production"
+          process.env.NODE_ENV === 'production'
             ? MiniCssExtractPlugin.loader
             : // Creates `style` nodes from JS strings
-              "style-loader",
+              'style-loader',
           // Translates CSS into CommonJS
-          "css-loader",
+          'css-loader',
           // Compiles Sass to CSS
-          "sass-loader",
-        ],
-      },
-    ],
+          'sass-loader'
+        ]
+      }
+    ]
   },
   optimization: {
     minimize: true,
@@ -47,13 +51,18 @@ module.exports = {
       new CssMinimizerPlugin({
         minimizerOptions: {
           preset: [
-            "default",
+            'default',
             {
-              discardComments: { removeAll: true },
-            },
-          ],
-        },
-      }),
-    ],
+              discardComments: { removeAll: true }
+            }
+          ]
+        }
+      })
+    ]
   },
+  resolve: {
+    alias: {
+      src: path.resolve(__dirname, 'src')
+    }
+  }
 };


### PR DESCRIPTION

![May-03-2021 02-02-01](https://user-images.githubusercontent.com/43772082/116821435-d622cd00-abb4-11eb-8748-9c2562158947.gif)

### Task
`Add new List`를 누르면, 새로운 칼럼의 타이틀을 입력하는 폼이 생성된다.
1자 이상 30자 이하의 타이틀을 입력후, Add List 버튼을 클릭 시, 새로운 칼럼이 생성된다.

### WIL
- 지역 컴포넌트 생성하고, 사용하기
- sass의 mixin 사용
- 런타임 빌드 vs 런타임 + 컴파일러 => 정리필요..!
- 자식 컴포넌트에서 부모 컴포넌트로 이벤트 전파
- computed를 사용하여 validation 체크
- `v-bind:eventname` 의 약어 `@eventname`


### 🔖체크리스트
- [x] "Add another list"를 클릭하면 칼럼의 이름을 입력할 수 있는 폼이 보여진다.
- [x] 칼럼의 이름은 1자 이상 30자 이하여야 한다.
- [x] 칼럼에 빈 내용이 있을 경우 버튼은 비활성화 되어야 한다.
- [x] 칼럼에 내용이 있을 경우, 버튼은 활성화된다.
- [x] 제출 버튼을 누르지 않은 채로 `X`를 클릭하면, 생성폼은 닫힌다.
- [ ] 제출 버튼을 누르지 않은 채로  다른 영역을 클릭하면, 생성폼은 닫힌다.
- [x] 제출 버튼을 누르면, 입력한 타이틀과 함께  빈 칼럼이 생긴다.


### Linked Issue
#8 