### PR TITLE
서버로부터 데이터 가져와서 세팅하기 - vuex

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,5 +10,8 @@ module.exports = {
     node: true,
     es6: true,
     jest: true
+  },
+  rules: {
+    'no-param-reassign': 0
   }
 };

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "src/*": ["./src/*"],
+    }
+  },
+  "exclude": ["node_modules", "dist"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "version": "0.1.0",
       "dependencies": {
+        "axios": "^0.21.1",
         "vue": "^2.6.11",
         "vuex": "^3.6.2"
       },
@@ -1750,6 +1751,14 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
       "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
       "dev": true
+    },
+    "node_modules/axios": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+      "dependencies": {
+        "follow-redirects": "^1.10.0"
+      }
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -5168,7 +5177,6 @@
       "version": "1.14.0",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.0.tgz",
       "integrity": "sha512-0vRwd7RKQBTt+mgu87mtYeofLFZpTas2S9zY+jIeuLJMNvudIgF52nr19q40HOwH5RrhWIPuj9puybzSJiRrVg==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -14868,6 +14876,14 @@
       "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
       "dev": true
     },
+    "axios": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+      "requires": {
+        "follow-redirects": "^1.10.0"
+      }
+    },
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -17690,8 +17706,7 @@
     "follow-redirects": {
       "version": "1.14.0",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.0.tgz",
-      "integrity": "sha512-0vRwd7RKQBTt+mgu87mtYeofLFZpTas2S9zY+jIeuLJMNvudIgF52nr19q40HOwH5RrhWIPuj9puybzSJiRrVg==",
-      "dev": true
+      "integrity": "sha512-0vRwd7RKQBTt+mgu87mtYeofLFZpTas2S9zY+jIeuLJMNvudIgF52nr19q40HOwH5RrhWIPuj9puybzSJiRrVg=="
     },
     "for-in": {
       "version": "1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,8 @@
     "": {
       "version": "0.1.0",
       "dependencies": {
-        "vue": "^2.6.11"
+        "vue": "^2.6.11",
+        "vuex": "^3.6.2"
       },
       "devDependencies": {
         "@vue/cli-plugin-eslint": "~4.5.0",
@@ -12036,6 +12037,14 @@
       "integrity": "sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==",
       "dev": true
     },
+    "node_modules/vuex": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/vuex/-/vuex-3.6.2.tgz",
+      "integrity": "sha512-ETW44IqCgBpVomy520DT5jf8n0zoCac+sxWnn+hMe/CzaSejb/eVw2YToiXYX+Ex/AuHHia28vWTq4goAexFbw==",
+      "peerDependencies": {
+        "vue": "^2.0.0"
+      }
+    },
     "node_modules/watchpack": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.1.1.tgz",
@@ -23132,6 +23141,12 @@
       "resolved": "https://registry.npmjs.org/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz",
       "integrity": "sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==",
       "dev": true
+    },
+    "vuex": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/vuex/-/vuex-3.6.2.tgz",
+      "integrity": "sha512-ETW44IqCgBpVomy520DT5jf8n0zoCac+sxWnn+hMe/CzaSejb/eVw2YToiXYX+Ex/AuHHia28vWTq4goAexFbw==",
+      "requires": {}
     },
     "watchpack": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "webpack serve --mode=development --open"
   },
   "dependencies": {
-    "vue": "^2.6.11"
+    "vue": "^2.6.11",
+    "vuex": "^3.6.2"
   },
   "devDependencies": {
     "@vue/cli-plugin-eslint": "~4.5.0",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start": "webpack serve --mode=development --open"
   },
   "dependencies": {
+    "axios": "^0.21.1",
     "vue": "^2.6.11",
     "vuex": "^3.6.2"
   },

--- a/src/apis/index.js
+++ b/src/apis/index.js
@@ -1,0 +1,6 @@
+import axios from 'src/settings/axios';
+import { ALL_COLUMNS_URL } from './urls';
+
+export const getColumns = async () => {
+  return axios.get(ALL_COLUMNS_URL);
+};

--- a/src/apis/urls.js
+++ b/src/apis/urls.js
@@ -1,0 +1,2 @@
+export const ALL_COLUMNS_URL =
+  'https://my-json-server.typicode.com/yejineee/vue-trello/columns';

--- a/src/components/AppComponent.vue
+++ b/src/components/AppComponent.vue
@@ -5,10 +5,12 @@
   </div>
 </template>
 <script>
+import store from '../stores/column/index';
 import Board from './Board.vue';
 import MainHeader from './MainHeader.vue';
 
 export default {
+  store,
   components: {
     MainHeader,
     Board

--- a/src/components/Board.vue
+++ b/src/components/Board.vue
@@ -1,7 +1,7 @@
 <template>
   <div id="board">
     <column
-      v-for="column in columnList"
+      v-for="column in columns"
       :key="column.id"
       :title="column.title"
     ></column>
@@ -9,6 +9,7 @@
   </div>
 </template>
 <script>
+import { mapState, mapGetters, mapMutations, mapActions } from 'vuex';
 import Column from './Column.vue';
 import ColumnForm from './ColumnForm.vue';
 
@@ -21,6 +22,9 @@ export default {
     return {
       columnList: [{ id: 1, title: 'todo' }]
     };
+  },
+  computed: {
+    ...mapState(['columns'])
   },
   methods: {
     onAddNewColumn(title) {

--- a/src/components/Board.vue
+++ b/src/components/Board.vue
@@ -10,7 +10,7 @@
 </template>
 <script>
 import { mapState, mapGetters, mapMutations, mapActions } from 'vuex';
-import { FETCH_COLUMNS } from '../stores/column/constants';
+import { FETCH_COLUMNS } from 'src/stores/column/constants';
 import Column from './Column.vue';
 import ColumnForm from './ColumnForm.vue';
 

--- a/src/components/Board.vue
+++ b/src/components/Board.vue
@@ -10,6 +10,7 @@
 </template>
 <script>
 import { mapState, mapGetters, mapMutations, mapActions } from 'vuex';
+import { FETCH_COLUMNS } from '../stores/column/constants';
 import Column from './Column.vue';
 import ColumnForm from './ColumnForm.vue';
 
@@ -26,10 +27,14 @@ export default {
   computed: {
     ...mapState(['columns'])
   },
+  created() {
+    this.fetchColumns();
+  },
   methods: {
     onAddNewColumn(title) {
       this.columnList.push({ id: `new-column-${title}`, title });
-    }
+    },
+    ...mapActions({ fetchColumns: FETCH_COLUMNS })
   }
 };
 </script>

--- a/src/settings/axios.js
+++ b/src/settings/axios.js
@@ -1,0 +1,19 @@
+import axios from 'axios';
+
+const instance = axios.create();
+
+instance.interceptors.request.use(
+  config => config,
+  error => Promise.reject(error)
+);
+
+instance.interceptors.response.use(
+  response => {
+    return response.data;
+  },
+  error => {
+    return Promise.reject(error);
+  }
+);
+
+export default instance;

--- a/src/stores/column/constants.js
+++ b/src/stores/column/constants.js
@@ -1,0 +1,5 @@
+// actions
+export const FETCH_COLUMNS = 'FETCH_COLUMNS';
+
+// commit
+export const MUTATE_COLUMNS = 'MUTATE_COLUMNS';

--- a/src/stores/column/index.js
+++ b/src/stores/column/index.js
@@ -1,0 +1,40 @@
+import Vue from 'vue';
+import Vuex from 'vuex';
+import { getColumns } from 'src/apis/index';
+import { FETCH_COLUMNS, MUTATE_COLUMNS } from './constants';
+
+Vue.use(Vuex);
+
+/*
+columns: [{
+  id: string,
+  title: string,
+  createdAt: string,
+  cards: [
+    {
+      id: string,
+      title: string,
+      description: string,
+      createdAt: string,
+      authorId: string,
+    }
+  ]
+}]
+*/
+const store = new Vuex.Store({
+  state: {
+    columns: []
+  },
+  mutations: {
+    [MUTATE_COLUMNS](state, { data }) {
+      state.columns = data;
+    }
+  },
+  actions: {
+    async [FETCH_COLUMNS]({ commit }) {
+      commit(MUTATE_COLUMNS, { data: await getColumns() });
+    }
+  }
+});
+
+export default store;


### PR DESCRIPTION
서버로부터 columns 데이터를 가져오서 스토어의 state에 세팅한다.

흐름은 다음과 같다.
1. component instance가 생성된 후에 `created` 라이프 사이클 메소드가 호출된다.
2. 컴포넌트의 created 함수 안에서 비동기 api호출을 하는 action을 호출한다.
3. action에서 api호출을 한 뒤, 응답을 mutation에 전달한다.
4. mutation은 데이터를 받아서 state에 저장한다.
5. 해당 state를 바라보는 component는 그 state에 맞춰 업데이트된다.


![](https://i.imgur.com/6mFHEjX.png)