### PR TITLE
새로운 칼럼 추가시 서버에 추가 & state에 추가하기

### DIFF
--- a/src/apis/index.js
+++ b/src/apis/index.js
@@ -4,3 +4,7 @@ import { ALL_COLUMNS_URL } from './urls';
 export const getColumns = async () => {
   return axios.get(ALL_COLUMNS_URL);
 };
+
+export const createNewColumn = async columnData => {
+  return axios.post(ALL_COLUMNS_URL, columnData);
+};

--- a/src/components/Board.vue
+++ b/src/components/Board.vue
@@ -10,7 +10,7 @@
 </template>
 <script>
 import { mapState, mapGetters, mapMutations, mapActions } from 'vuex';
-import { FETCH_COLUMNS } from 'src/stores/column/constants';
+import { FETCH_COLUMNS, CREATE_COLUMN } from 'src/stores/column/constants';
 import Column from './Column.vue';
 import ColumnForm from './ColumnForm.vue';
 
@@ -29,8 +29,10 @@ export default {
     this.fetchColumns();
   },
   methods: {
-    onAddNewColumn(title) {},
-    ...mapActions({ fetchColumns: FETCH_COLUMNS })
+    onAddNewColumn(title) {
+      this.addNewColumn(title);
+    },
+    ...mapActions({ fetchColumns: FETCH_COLUMNS, addNewColumn: CREATE_COLUMN })
   }
 };
 </script>

--- a/src/components/Board.vue
+++ b/src/components/Board.vue
@@ -20,9 +20,7 @@ export default {
     ColumnForm
   },
   data() {
-    return {
-      columnList: [{ id: 1, title: 'todo' }]
-    };
+    return {};
   },
   computed: {
     ...mapState(['columns'])
@@ -31,9 +29,7 @@ export default {
     this.fetchColumns();
   },
   methods: {
-    onAddNewColumn(title) {
-      this.columnList.push({ id: `new-column-${title}`, title });
-    },
+    onAddNewColumn(title) {},
     ...mapActions({ fetchColumns: FETCH_COLUMNS })
   }
 };

--- a/src/stores/column/constants.js
+++ b/src/stores/column/constants.js
@@ -1,5 +1,7 @@
 // actions
 export const FETCH_COLUMNS = 'FETCH_COLUMNS';
+export const CREATE_COLUMN = 'CREATE_COLUMN';
 
 // commit
 export const MUTATE_COLUMNS = 'MUTATE_COLUMNS';
+export const MUTATE_ADD_COLUMN = 'MUTATE_ADD_COLUMN';

--- a/src/stores/column/index.js
+++ b/src/stores/column/index.js
@@ -1,7 +1,12 @@
 import Vue from 'vue';
 import Vuex from 'vuex';
-import { getColumns } from 'src/apis/index';
-import { FETCH_COLUMNS, MUTATE_COLUMNS } from './constants';
+import { getColumns, createNewColumn } from 'src/apis/index';
+import {
+  CREATE_COLUMN,
+  FETCH_COLUMNS,
+  MUTATE_COLUMNS,
+  MUTATE_ADD_COLUMN
+} from './constants';
 
 Vue.use(Vuex);
 
@@ -28,11 +33,22 @@ const store = new Vuex.Store({
   mutations: {
     [MUTATE_COLUMNS](state, { data }) {
       state.columns = data;
+    },
+    [MUTATE_ADD_COLUMN](state, { newColumn }) {
+      state.columns = [...state.columns, newColumn];
     }
   },
   actions: {
     async [FETCH_COLUMNS]({ commit }) {
       commit(MUTATE_COLUMNS, { data: await getColumns() });
+    },
+    async [CREATE_COLUMN]({ commit }, title) {
+      const newColumn = await createNewColumn({
+        title,
+        createdAt: new Date(),
+        cards: []
+      });
+      commit(MUTATE_ADD_COLUMN, { newColumn });
     }
   }
 });


### PR DESCRIPTION
## 💚 작업 내용
기존 코드는 새로운 칼럼을 추가하고자 하면, 컴포넌트의 state에 새로운 칼럼을 추가하였다.
vuex로 상태관리를 하게 되었고, fake server를 사용함에 따라 내부 로직이 변경되었다.
새로운 칼럼 추가시 서버에 칼럼을 추가하고, state에도 새로운 칼럼을 추가하도록 하였다.

## WIL 
mutation에서 state에 새로운 데이터를 추가하고자 할 때, 기존 객체를 대체시켜야 한다.
```
state.obj = { ...state.obj, newProp: 123 }
```
또는 Vue.set을 사용한다.
```
Vue.set(obj, 'newProp', 123)
```

## ✅ 체크리스트

- [x] 서버에 POST 요청 보낸 후, store 업데이트한다.
- [x] 기존 component의 state는 삭제한다.
- [x] 유저가 새로운 칼럼을 추가하면, 유저가 설정한 이름으로 칼럼이 보여지게 된다.



## Linked Issues
closes #18 
