### PR TITLE
칼럼 타이틀 수정

### DIFF
--- a/src/apis/index.js
+++ b/src/apis/index.js
@@ -8,3 +8,7 @@ export const getColumns = async () => {
 export const createNewColumn = async columnData => {
   return axios.post(ALL_COLUMNS_URL, columnData);
 };
+
+export const updateColumnTitle = async (id, columnData) => {
+  return axios.patch(`${ALL_COLUMNS_URL}/${id}`, columnData);
+};

--- a/src/components/Board.vue
+++ b/src/components/Board.vue
@@ -3,7 +3,7 @@
     <column
       v-for="column in columns"
       :key="column.id"
-      :title="column.title"
+      :column="column"
     ></column>
     <column-form @add-new-column="onAddNewColumn"></column-form>
   </div>

--- a/src/components/Board.vue
+++ b/src/components/Board.vue
@@ -39,12 +39,10 @@ export default {
 <style lang="scss">
 #board {
   display: flex;
-  top: 0;
-  left: 0;
   width: 100%;
   height: 95vh;
+  padding: 1rem;
 
   overflow-x: scroll;
-  border: 1px solid red;
 }
 </style>

--- a/src/components/Column.vue
+++ b/src/components/Column.vue
@@ -8,9 +8,17 @@
 <script>
 export default {
   props: {
-    title: {
-      type: String,
-      required: true
+    column: {
+      type: Object,
+      required: true,
+      validator({ id, title, createdAt, cards }) {
+        return (
+          typeof id === 'string' &&
+          typeof title === 'string' &&
+          (typeof createdAt === 'string' || createdAt instanceof Date) &&
+          cards instanceof Array
+        );
+      }
     }
   }
 };

--- a/src/components/Column.vue
+++ b/src/components/Column.vue
@@ -23,6 +23,9 @@ export default {
   @include round-box;
   @include column-base;
   background: $column-back;
+  & + & {
+    margin-left: 0.5rem;
+  }
 }
 .column__title {
   @include round-box;

--- a/src/components/Column.vue
+++ b/src/components/Column.vue
@@ -41,13 +41,24 @@ export default {
       maxTitle: MAX_TITLE_LENGTH
     };
   },
+  computed: {
+    isValidTitle() {
+      return (
+        this.updatedTitle.length >= this.minTitle &&
+        this.updatedTitle.length <= this.maxTitle
+      );
+    }
+  },
   methods: {
     toggleEditTitleForm() {
       this.showEditForm = this.showEditForm !== true;
     },
     submitUpdatedTitle() {
-      this.updateTitle({ title: this.updatedTitle, id: this.column.id });
       this.showEditForm = false;
+      if (!this.isValidTitle) {
+        return;
+      }
+      this.updateTitle({ title: this.updatedTitle, id: this.column.id });
     },
     ...mapActions({ updateTitle: UPDATE_COLUMN })
   }

--- a/src/components/Column.vue
+++ b/src/components/Column.vue
@@ -1,11 +1,23 @@
 <template>
   <div class="column">
-    <div class="column__title">
-      {{ title }}
+    <form v-if="showEditForm" @submit.prevent="submitUpdatedTitle">
+      <input
+        id="column__title-edit-form"
+        v-model="updatedTitle"
+        :minlength="minTitle"
+        :maxlength="maxTitle"
+      />
+    </form>
+    <div v-else class="column__title" @click="toggleEditTitleForm">
+      {{ column.title }}
     </div>
   </div>
 </template>
 <script>
+import { MAX_TITLE_LENGTH, MIN_TITLE_LENGTH } from 'src/constants/title';
+import { mapActions } from 'vuex';
+import { UPDATE_COLUMN } from 'src/stores/column/constants';
+
 export default {
   props: {
     column: {
@@ -20,6 +32,24 @@ export default {
         );
       }
     }
+  },
+  data() {
+    return {
+      showEditForm: false,
+      updatedTitle: this.column.title,
+      minTitle: MIN_TITLE_LENGTH,
+      maxTitle: MAX_TITLE_LENGTH
+    };
+  },
+  methods: {
+    toggleEditTitleForm() {
+      this.showEditForm = this.showEditForm !== true;
+    },
+    submitUpdatedTitle() {
+      this.updateTitle({ title: this.updatedTitle, id: this.column.id });
+      this.showEditForm = false;
+    },
+    ...mapActions({ updateTitle: UPDATE_COLUMN })
   }
 };
 </script>
@@ -44,5 +74,14 @@ export default {
     weight: 500;
   }
   background: $column-back;
+}
+
+#column__title-edit-form {
+  @include column-title-base;
+  @include column-base;
+  display: flex;
+  margin: auto;
+  width: 90%;
+  padding: 0.5rem 0;
 }
 </style>

--- a/src/components/ColumnForm.vue
+++ b/src/components/ColumnForm.vue
@@ -81,6 +81,7 @@ $padding: 0.5rem 0;
 #column-form {
   @include round-box;
   @include column-base;
+  margin-left: 0.5rem;
 }
 
 #column-form__button {

--- a/src/stores/column/constants.js
+++ b/src/stores/column/constants.js
@@ -1,7 +1,9 @@
 // actions
 export const FETCH_COLUMNS = 'FETCH_COLUMNS';
 export const CREATE_COLUMN = 'CREATE_COLUMN';
+export const UPDATE_COLUMN = 'UPDATE_COLUMN';
 
 // commit
 export const MUTATE_COLUMNS = 'MUTATE_COLUMNS';
 export const MUTATE_ADD_COLUMN = 'MUTATE_ADD_COLUMN';
+export const MUTATE_COLUMN_NAME = 'MUTATE_COLUMN_NAME';

--- a/src/stores/column/index.js
+++ b/src/stores/column/index.js
@@ -1,11 +1,13 @@
 import Vue from 'vue';
 import Vuex from 'vuex';
-import { getColumns, createNewColumn } from 'src/apis/index';
+import { getColumns, createNewColumn, updateColumnTitle } from 'src/apis/index';
 import {
   CREATE_COLUMN,
   FETCH_COLUMNS,
+  UPDATE_COLUMN,
   MUTATE_COLUMNS,
-  MUTATE_ADD_COLUMN
+  MUTATE_ADD_COLUMN,
+  MUTATE_COLUMN_NAME
 } from './constants';
 
 Vue.use(Vuex);
@@ -36,6 +38,9 @@ const store = new Vuex.Store({
     },
     [MUTATE_ADD_COLUMN](state, { newColumn }) {
       state.columns = [...state.columns, newColumn];
+    },
+    [MUTATE_COLUMN_NAME](state, { idx, title }) {
+      state.columns[idx].title = title;
     }
   },
   actions: {
@@ -49,6 +54,19 @@ const store = new Vuex.Store({
         cards: []
       });
       commit(MUTATE_ADD_COLUMN, { newColumn });
+    },
+    async [UPDATE_COLUMN]({ commit, getters }, { id, title }) {
+      const updatedColumn = await updateColumnTitle(id, { title });
+      const idx = getters.getIdxOfColumnId(updatedColumn.id);
+      if (idx === -1) {
+        return;
+      }
+      commit(MUTATE_COLUMN_NAME, { idx, title: updatedColumn.title });
+    }
+  },
+  getters: {
+    getIdxOfColumnId: state => targetId => {
+      return state.columns.findIndex(({ id }) => id === targetId);
     }
   }
 });

--- a/src/style/mixin.scss
+++ b/src/style/mixin.scss
@@ -1,6 +1,6 @@
 @mixin round-box{
   @content;
-  border-radius: 4%;
+  border-radius: 6px;
 }
 
 @mixin flex-center{


### PR DESCRIPTION
![title수정](https://user-images.githubusercontent.com/43772082/117108541-4e101380-adbe-11eb-97a6-ae67ec9f5d2d.gif)

## 💚 작업 내용
타이틀을 클릭하면, 타이틀 수정폼이 보이고, 타이틀을 수정할 수 있다.
엔터를 누르면 수정된 타이틀이 반영된다.
만약 입력한 내용이 없으면, 수정이 반영되지 않는다.

## ✅ 체크리스트
### 🔖체크리스트
- [x]  칼럼의 이름은 1자 이상 30자 이하여야 한다.
- [x] 30자 이상을 입력하면, 30자까지만 저장한다.
- [x] 내용을 수정한 후, 엔터를 치면 수정된 타이틀이 반영된다.
- [x] 엔터를 쳤을 때, 칼럼에 빈 내용이 있으면, 타이틀은 수정되지 않고 기존 타이틀이 적용된다.
- [ ] 다른 영역을 클릭하면, 입력한 제목이 반영된다.
- [ ] 다른 영역을 클릭하였을 때, 칼럼에 빈 내용이 있으면, 타이틀은 수정되지 않고 기존 타이틀이 적용된다.

## Linked Issues
#22 
