### PR TITLE
타이틀 입력 폼 바깥의 배경을 클릭 시 폼이 저장되고 닫히는 기능

### DIFF
--- a/src/components/Column.vue
+++ b/src/components/Column.vue
@@ -1,13 +1,12 @@
 <template>
   <div class="column">
-    <form v-if="showEditForm" @submit.prevent="submitUpdatedTitle">
-      <input
-        id="column__title-edit-form"
-        v-model="updatedTitle"
-        :minlength="minTitle"
-        :maxlength="maxTitle"
-      />
-    </form>
+    <ColumnEditForm
+      v-if="showEditForm"
+      :id="column.id"
+      :title="column.title"
+      @update-title="toggleEditTitleForm"
+    >
+    </ColumnEditForm>
     <div v-else class="column__title" @click="toggleEditTitleForm">
       {{ column.title }}
     </div>
@@ -15,10 +14,12 @@
 </template>
 <script>
 import { MAX_TITLE_LENGTH, MIN_TITLE_LENGTH } from 'src/constants/title';
-import { mapActions } from 'vuex';
-import { UPDATE_COLUMN } from 'src/stores/column/constants';
+import ColumnEditForm from './ColumnEditForm.vue';
 
 export default {
+  components: {
+    ColumnEditForm
+  },
   props: {
     column: {
       type: Object,
@@ -52,15 +53,7 @@ export default {
   methods: {
     toggleEditTitleForm() {
       this.showEditForm = this.showEditForm !== true;
-    },
-    submitUpdatedTitle() {
-      this.showEditForm = false;
-      if (!this.isValidTitle) {
-        return;
-      }
-      this.updateTitle({ title: this.updatedTitle, id: this.column.id });
-    },
-    ...mapActions({ updateTitle: UPDATE_COLUMN })
+    }
   }
 };
 </script>

--- a/src/components/ColumnEditForm.vue
+++ b/src/components/ColumnEditForm.vue
@@ -1,0 +1,78 @@
+<template>
+  <form @submit.prevent="submitUpdatedTitle">
+    <input
+      id="column__title-edit-form"
+      v-model="updatedTitle"
+      :minlength="minTitle"
+      :maxlength="maxTitle"
+      @click.stop
+    />
+  </form>
+</template>
+<script>
+import { MAX_TITLE_LENGTH, MIN_TITLE_LENGTH } from 'src/constants/title';
+import { mapActions } from 'vuex';
+import { UPDATE_COLUMN } from 'src/stores/column/constants';
+
+export default {
+  props: {
+    title: {
+      type: String,
+      required: true
+    },
+    id: {
+      type: String,
+      required: true
+    }
+  },
+  data() {
+    return {
+      updatedTitle: this.title,
+      minTitle: MIN_TITLE_LENGTH,
+      maxTitle: MAX_TITLE_LENGTH
+    };
+  },
+  computed: {
+    isValidTitle() {
+      return (
+        this.updatedTitle.length >= this.minTitle &&
+        this.updatedTitle.length <= this.maxTitle
+      );
+    }
+  },
+  created() {
+    window.addEventListener('click', this.clickOuterHandler);
+  },
+  destroyed() {
+    window.removeEventListener('click', this.clickOuterHandler);
+  },
+  methods: {
+    clickOuterHandler({ target }) {
+      if (target.className === 'column__title') {
+        return;
+      }
+      this.submitUpdatedTitle();
+    },
+    submitUpdatedTitle() {
+      this.$emit('update-title');
+      if (!this.isValidTitle) {
+        return;
+      }
+      this.updateTitle({ title: this.updatedTitle, id: this.id });
+    },
+    ...mapActions({ updateTitle: UPDATE_COLUMN })
+  }
+};
+</script>
+<style lang="scss">
+@import 'src/style/mixin.scss';
+
+#column__title-edit-form {
+  @include column-title-base;
+  @include column-base;
+  display: flex;
+  margin: auto;
+  width: 90%;
+  padding: 0.5rem 0;
+}
+</style>


### PR DESCRIPTION

![title 수정 - 바깥](https://user-images.githubusercontent.com/43772082/117135728-4ebaa100-ade2-11eb-9dd3-b990e93c3260.gif)

## 💚 작업 내용
타이틀 수정 폼의 바깥을 클릭하였을 경우, 입력했던 내용으로 타이틀이 수정되는 기능을 추가하였다.

## ✅ 체크리스트
- [X] 다른 영역을 클릭하면, 입력한 제목이 반영된다.
- [x] 엔터를 치거나 다른 영역을 클릭하였을 때, 칼럼에 빈 내용이 있으면, 타이틀은 수정되지 않고 기존 타이틀이 적용된다.

## Linked Issues
closes #22
