### PR TITLE
스토어를 유저 스토어, 칼럼 스토어로 모듈화하기 & 타이틀을 유저 스토어의 이름으로 하기

### DIFF
--- a/src/apis/index.js
+++ b/src/apis/index.js
@@ -1,5 +1,5 @@
 import axios from 'src/settings/axios';
-import { ALL_COLUMNS_URL } from './urls';
+import { ALL_COLUMNS_URL, USER_URL } from './urls';
 
 export const getColumns = async () => {
   return axios.get(ALL_COLUMNS_URL);
@@ -11,4 +11,8 @@ export const createNewColumn = async columnData => {
 
 export const updateColumnTitle = async (id, columnData) => {
   return axios.patch(`${ALL_COLUMNS_URL}/${id}`, columnData);
+};
+
+export const getUserData = async () => {
+  return axios.get(USER_URL);
 };

--- a/src/apis/urls.js
+++ b/src/apis/urls.js
@@ -1,2 +1,5 @@
 export const ALL_COLUMNS_URL =
   'https://my-json-server.typicode.com/yejineee/vue-trello/columns';
+
+export const USER_URL =
+  'https://my-json-server.typicode.com/yejineee/vue-trello/user';

--- a/src/components/AppComponent.vue
+++ b/src/components/AppComponent.vue
@@ -5,12 +5,10 @@
   </div>
 </template>
 <script>
-import store from '../stores/column/index';
 import Board from './Board.vue';
 import MainHeader from './MainHeader.vue';
 
 export default {
-  store,
   components: {
     MainHeader,
     Board

--- a/src/components/AppComponent.vue
+++ b/src/components/AppComponent.vue
@@ -5,6 +5,8 @@
   </div>
 </template>
 <script>
+import { mapActions } from 'vuex';
+import { FETCH_USER, USER_STORE_NAME } from 'src/stores/user/constants';
 import Board from './Board.vue';
 import MainHeader from './MainHeader.vue';
 
@@ -12,6 +14,12 @@ export default {
   components: {
     MainHeader,
     Board
+  },
+  created() {
+    this.fetchUser();
+  },
+  methods: {
+    ...mapActions(USER_STORE_NAME, { fetchUser: FETCH_USER })
   }
 };
 </script>

--- a/src/components/Board.vue
+++ b/src/components/Board.vue
@@ -10,7 +10,7 @@
 </template>
 <script>
 import { mapState, mapActions } from 'vuex';
-import { FETCH_COLUMNS } from 'src/stores/column/constants';
+import { FETCH_COLUMNS, COLUMN_STORE_NAME } from 'src/stores/column/constants';
 import Column from './Column.vue';
 import ColumnForm from './ColumnForm.vue';
 
@@ -23,13 +23,13 @@ export default {
     return {};
   },
   computed: {
-    ...mapState(['columns'])
+    ...mapState(COLUMN_STORE_NAME, ['columns'])
   },
   created() {
     this.fetchColumns();
   },
   methods: {
-    ...mapActions({ fetchColumns: FETCH_COLUMNS })
+    ...mapActions(COLUMN_STORE_NAME, { fetchColumns: FETCH_COLUMNS })
   }
 };
 </script>

--- a/src/components/ColumnEditForm.vue
+++ b/src/components/ColumnEditForm.vue
@@ -12,7 +12,7 @@
 <script>
 import { MAX_TITLE_LENGTH, MIN_TITLE_LENGTH } from 'src/constants/title';
 import { mapActions } from 'vuex';
-import { UPDATE_COLUMN } from 'src/stores/column/constants';
+import { UPDATE_COLUMN, COLUMN_STORE_NAME } from 'src/stores/column/constants';
 
 export default {
   props: {
@@ -60,7 +60,7 @@ export default {
       }
       this.updateTitle({ title: this.updatedTitle, id: this.id });
     },
-    ...mapActions({ updateTitle: UPDATE_COLUMN })
+    ...mapActions(COLUMN_STORE_NAME, { updateTitle: UPDATE_COLUMN })
   }
 };
 </script>

--- a/src/components/ColumnForm.vue
+++ b/src/components/ColumnForm.vue
@@ -33,7 +33,7 @@
 </template>
 <script>
 import { mapActions } from 'vuex';
-import { CREATE_COLUMN } from 'src/stores/column/constants';
+import { CREATE_COLUMN, COLUMN_STORE_NAME } from 'src/stores/column/constants';
 import { MAX_TITLE_LENGTH, MIN_TITLE_LENGTH } from '../constants/title';
 
 export default {
@@ -68,7 +68,7 @@ export default {
       this.showForm = false;
       this.title = '';
     },
-    ...mapActions({ addNewColumn: CREATE_COLUMN })
+    ...mapActions(COLUMN_STORE_NAME, { addNewColumn: CREATE_COLUMN })
   }
 };
 </script>

--- a/src/components/MainHeader.vue
+++ b/src/components/MainHeader.vue
@@ -4,11 +4,15 @@
   </header>
 </template>
 <script>
+import { USER_STORE_NAME } from 'src/stores/user/constants';
+import { mapState } from 'vuex';
+
 export default {
-  data() {
-    return {
-      title: "Lillie's Trello"
-    };
+  computed: {
+    title() {
+      return this.name ? `${this.name}'s Trello` : '';
+    },
+    ...mapState(USER_STORE_NAME, ['name'])
   }
 };
 </script>

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,12 @@
 // src/index.js
 import Vue from 'vue';
+import store from 'src/stores';
 import AppComponent from './components/AppComponent.vue';
 import './style/reset.scss';
 // root element
 new Vue({
-  el: '#body',
   render(h) {
     return h(AppComponent);
-  }
-});
+  },
+  store
+}).$mount('body');

--- a/src/stores/column/constants.js
+++ b/src/stores/column/constants.js
@@ -1,3 +1,4 @@
+export const COLUMN_STORE_NAME = 'column';
 // actions
 export const FETCH_COLUMNS = 'FETCH_COLUMNS';
 export const CREATE_COLUMN = 'CREATE_COLUMN';

--- a/src/stores/column/index.js
+++ b/src/stores/column/index.js
@@ -1,5 +1,3 @@
-import Vue from 'vue';
-import Vuex from 'vuex';
 import { getColumns, createNewColumn, updateColumnTitle } from 'src/apis/index';
 import {
   CREATE_COLUMN,
@@ -10,25 +8,7 @@ import {
   MUTATE_COLUMN_NAME
 } from './constants';
 
-Vue.use(Vuex);
-
-/*
-columns: [{
-  id: string,
-  title: string,
-  createdAt: string,
-  cards: [
-    {
-      id: string,
-      title: string,
-      description: string,
-      createdAt: string,
-      authorId: string,
-    }
-  ]
-}]
-*/
-const store = new Vuex.Store({
+const columnModule = {
   state: {
     columns: []
   },
@@ -69,6 +49,6 @@ const store = new Vuex.Store({
       return state.columns.findIndex(({ id }) => id === targetId);
     }
   }
-});
+};
 
-export default store;
+export default columnModule;

--- a/src/stores/column/index.js
+++ b/src/stores/column/index.js
@@ -9,9 +9,10 @@ import {
 } from './constants';
 
 const columnModule = {
-  state: {
+  namespaced: true,
+  state: () => ({
     columns: []
-  },
+  }),
   mutations: {
     [MUTATE_COLUMNS](state, { data }) {
       state.columns = data;

--- a/src/stores/index.js
+++ b/src/stores/index.js
@@ -2,13 +2,15 @@ import Vue from 'vue';
 import Vuex from 'vuex';
 import userModule from './user';
 import columnModule from './column';
+import { USER_STORE_NAME } from './user/constants';
+import { COLUMN_STORE_NAME } from './column/constants';
 
 Vue.use(Vuex);
 
 const store = new Vuex.Store({
   modules: {
-    userModule,
-    columnModule
+    [USER_STORE_NAME]: userModule,
+    [COLUMN_STORE_NAME]: columnModule
   }
 });
 

--- a/src/stores/index.js
+++ b/src/stores/index.js
@@ -1,0 +1,15 @@
+import Vue from 'vue';
+import Vuex from 'vuex';
+import userModule from './user';
+import columnModule from './column';
+
+Vue.use(Vuex);
+
+const store = new Vuex.Store({
+  modules: {
+    userModule,
+    columnModule
+  }
+});
+
+export default store;

--- a/src/stores/user/constants.js
+++ b/src/stores/user/constants.js
@@ -1,1 +1,5 @@
 export const USER_STORE_NAME = 'user';
+// mutations
+export const MUTATE_USER = 'MUTATE_USER';
+// actions
+export const FETCH_USER = 'FETCH_USER';

--- a/src/stores/user/constants.js
+++ b/src/stores/user/constants.js
@@ -1,0 +1,1 @@
+export const USER_STORE_NAME = 'user';

--- a/src/stores/user/index.js
+++ b/src/stores/user/index.js
@@ -1,4 +1,5 @@
 const userModule = {
+  namespaced: true,
   state: () => ({
     id: null,
     name: null

--- a/src/stores/user/index.js
+++ b/src/stores/user/index.js
@@ -1,0 +1,11 @@
+const userModule = {
+  state: () => ({
+    id: null,
+    name: null
+  }),
+  mutations: {},
+  actions: {},
+  getters: {}
+};
+
+export default userModule;

--- a/src/stores/user/index.js
+++ b/src/stores/user/index.js
@@ -1,12 +1,23 @@
+import { getUserData } from 'src/apis';
+import { MUTATE_USER, FETCH_USER } from './constants';
+
 const userModule = {
   namespaced: true,
   state: () => ({
     id: null,
     name: null
   }),
-  mutations: {},
-  actions: {},
-  getters: {}
+  mutations: {
+    [MUTATE_USER](state, { data: { id, name } }) {
+      state.id = id;
+      state.name = name;
+    }
+  },
+  actions: {
+    async [FETCH_USER]({ commit }) {
+      commit(MUTATE_USER, { data: await getUserData() });
+    }
+  }
 };
 
 export default userModule;


### PR DESCRIPTION
## 💚 작업 내용
1. 스토어를 유저 스토어와 칼럼 스토어로 모듈화하였고, namespace를 갖도록 하였다.
2. namespaced module이 됨에 따라, 컴포넌트에서 기존 column store에서의 dispach나 commit, state 접근시 column의 namspace를 추가하였다.
3. 타이틀을 유저 스토어의 이름을 가져와서`${name} 's Trello`형식이 되도록 수정하였다.

## ✅ 체크리스트
- [X] 유저 모듈에 있는 state에 접근하여, 현재 로그인한 유저의 이름을 제목에 반영한다.
- [x] 유저 모듈을 스토어에 등록한다.
- [ ] 해당 모듈에 있는 userId를 칼럼 생성 시, authorId에 추가한다.
- [x] 유저 모듈은 namespace를 갖도록 한다.

## Linked Issues
closes #32 
#31 
