### PR TITLE
router의 params에 맞춰 동적으로 칼럼의  데이터 Fetch하기

### DIFF
--- a/src/apis/index.js
+++ b/src/apis/index.js
@@ -1,8 +1,8 @@
 import axios from 'src/settings/axios';
 import { ALL_COLUMNS_URL, USER_URL, BOARDS_URL } from './urls';
 
-export const getColumns = async () => {
-  return axios.get(ALL_COLUMNS_URL);
+export const getColumns = async id => {
+  return axios.get(`${BOARDS_URL}/${id}`);
 };
 
 export const createNewColumn = async columnData => {

--- a/src/apis/urls.js
+++ b/src/apis/urls.js
@@ -1,8 +1,3 @@
-export const ALL_COLUMNS_URL =
-  'https://my-json-server.typicode.com/yejineee/vue-trello/columns';
-
-export const USER_URL =
-  'https://my-json-server.typicode.com/yejineee/vue-trello/user';
-
-export const BOARDS_URL =
-  'https://my-json-server.typicode.com/yejineee/vue-trello/boards';
+export const ALL_COLUMNS_URL = '/columns';
+export const USER_URL = '/user';
+export const BOARDS_URL = '/boards';

--- a/src/components/Board.vue
+++ b/src/components/Board.vue
@@ -26,7 +26,8 @@ export default {
     ...mapState(COLUMN_STORE_NAME, ['columns'])
   },
   created() {
-    this.fetchColumns();
+    const { boardId } = this.$route.params;
+    this.fetchColumns({ boardId });
   },
   methods: {
     ...mapActions(COLUMN_STORE_NAME, { fetchColumns: FETCH_COLUMNS })

--- a/src/components/Board.vue
+++ b/src/components/Board.vue
@@ -25,12 +25,20 @@ export default {
   computed: {
     ...mapState(COLUMN_STORE_NAME, ['columns'])
   },
+  watch: {
+    $route(to) {
+      this.fetchColumnsByBoardId(to);
+    }
+  },
   created() {
-    const { boardId } = this.$route.params;
-    this.fetchColumns({ boardId });
+    this.fetchColumnsByBoardId();
   },
   methods: {
-    ...mapActions(COLUMN_STORE_NAME, { fetchColumns: FETCH_COLUMNS })
+    ...mapActions(COLUMN_STORE_NAME, { fetchColumns: FETCH_COLUMNS }),
+    fetchColumnsByBoardId(route = this.$route) {
+      const { boardId } = route.params;
+      this.fetchColumns({ boardId });
+    }
   }
 };
 </script>

--- a/src/components/BoardList.vue
+++ b/src/components/BoardList.vue
@@ -1,27 +1,23 @@
 <template>
   <ul id="board-list">
     <board-card
-      v-for="board in boardList"
+      v-for="board in boards"
       :key="board.id"
       :board="board"
     ></board-card>
   </ul>
 </template>
 <script>
-import { mapActions, mapGetters } from 'vuex';
+import { mapActions, mapState } from 'vuex';
 import BoardCard from 'src/components/BoardCard.vue';
-import {
-  BOARD_STORE_NAME,
-  FETCH_BOARDS,
-  boardList
-} from 'src/stores/board/constants';
+import { BOARD_STORE_NAME, FETCH_BOARDS } from 'src/stores/board/constants';
 
 export default {
   components: {
     BoardCard
   },
   computed: {
-    ...mapGetters(BOARD_STORE_NAME, [boardList])
+    ...mapState(BOARD_STORE_NAME, ['boards'])
   },
   created() {
     this.fetchBoards();

--- a/src/components/MainHeader.vue
+++ b/src/components/MainHeader.vue
@@ -1,17 +1,19 @@
 <template>
   <header id="header">
-    {{ title }}
+    {{ headerTitle }}
   </header>
 </template>
 <script>
 import { USER_STORE_NAME } from 'src/stores/user/constants';
+import { COLUMN_STORE_NAME } from 'src/stores/column/constants';
 import { mapState } from 'vuex';
 
 export default {
   computed: {
-    title() {
-      return this.name ? `${this.name}'s Trello` : '';
+    headerTitle() {
+      return this.name && this.title ? `${this.name}'s ${this.title}` : '';
     },
+    ...mapState(COLUMN_STORE_NAME, ['title']),
     ...mapState(USER_STORE_NAME, ['name'])
   }
 };

--- a/src/settings/axios.js
+++ b/src/settings/axios.js
@@ -1,6 +1,8 @@
 import axios from 'axios';
 
-const instance = axios.create();
+const instance = axios.create({
+  baseURL: 'https://my-json-server.typicode.com/yejineee/vue-trello'
+});
 
 instance.interceptors.request.use(
   config => config,

--- a/src/stores/board/constants.js
+++ b/src/stores/board/constants.js
@@ -4,6 +4,3 @@ export const FETCH_BOARDS = 'FETCH_BOARDS';
 
 // mutation
 export const MUTATE_BOARDS = 'MUTATE_BOARDS';
-
-// getters
-export const boardList = 'boardList';

--- a/src/stores/board/index.js
+++ b/src/stores/board/index.js
@@ -1,10 +1,10 @@
 import { getBoards } from 'src/apis/index';
-import { FETCH_BOARDS, MUTATE_BOARDS, boardList } from './constants';
+import { FETCH_BOARDS, MUTATE_BOARDS } from './constants';
 
 const boardModule = {
   namespaced: true,
   state: () => ({
-    boards: null
+    boards: []
   }),
   mutations: {
     [MUTATE_BOARDS](state, { boards }) {
@@ -15,17 +15,6 @@ const boardModule = {
     async [FETCH_BOARDS]({ commit }) {
       const boards = await getBoards();
       commit(MUTATE_BOARDS, { boards });
-    }
-  },
-  getters: {
-    [boardList](state) {
-      if (state.boards === null) {
-        return [];
-      }
-      return Object.values(state.boards).map(({ id, title }) => ({
-        id,
-        title
-      }));
     }
   }
 };

--- a/src/stores/column/index.js
+++ b/src/stores/column/index.js
@@ -11,11 +11,17 @@ import {
 const columnModule = {
   namespaced: true,
   state: () => ({
+    boardId: null,
+    title: null,
+    imageUrl: null,
     columns: []
   }),
   mutations: {
-    [MUTATE_COLUMNS](state, { data }) {
-      state.columns = data;
+    [MUTATE_COLUMNS](state, { data: { id, title, imageUrl, columns } }) {
+      state.boardId = id;
+      state.title = title;
+      state.imageUrl = imageUrl;
+      state.columns = columns;
     },
     [MUTATE_ADD_COLUMN](state, { newColumn }) {
       state.columns = [...state.columns, newColumn];
@@ -25,8 +31,8 @@ const columnModule = {
     }
   },
   actions: {
-    async [FETCH_COLUMNS]({ commit }) {
-      commit(MUTATE_COLUMNS, { data: await getColumns() });
+    async [FETCH_COLUMNS]({ commit }, { boardId }) {
+      commit(MUTATE_COLUMNS, { data: await getColumns(boardId) });
     },
     async [CREATE_COLUMN]({ commit }, title) {
       const newColumn = await createNewColumn({


### PR DESCRIPTION
## 💚 작업 내용
1. 메인에서 선택한 보드에 맞춰 칼럼 데이터 가져오기
2. Route의 Params가 동적으로 변함에 따라 데이터 fetch하기
    - $route를 watch하여 params가 변경될 때, data fetch하기
3. 헤더의 이름을 사용자 + 보드의 타이틀로 지정하기
4. axios의 baseURL 설정
    - 동일한 baseURL을 반복해서 적지 않고, axios instance를 생성할 때, baseURL을 입력하여 중복을 없앤다.
   

## ✅ 체크리스트


## Linked Issues
closes #39 
